### PR TITLE
Support rejections with no argument

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# Editor configuration, see http://editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+max_line_length = 0
+trim_trailing_whitespace = false

--- a/index.js
+++ b/index.js
@@ -1,58 +1,23 @@
-const co = require('co');
 const Layer = require('express/lib/router/layer');
 
 Object.defineProperty(Layer.prototype, "handle", {
   enumerable: true,
   get: function() { return this.__handle; },
   set: function(fn) {
-    if (isGenerator(fn)) {
-      fn = wrapGenerator(fn);
-    }
-
-    if (isAsync(fn)) {
-      fn = wrapAsync(fn);
-    }
+    fn = wrap(fn);
 
     this.__handle = fn;
   }
 });
 
-function isGenerator(fn) {
-  const type = Object.toString.call(fn.constructor);
-  return type.indexOf('GeneratorFunction') !== -1;
-}
+function wrap(fn) {
+  return (req, res, next) => {
+    const routePromise = fn(req, res, next);
 
-function isAsync(fn) {
-  const type = Object.toString.call(fn.constructor);
-  return type.indexOf('AsyncFunction') !== -1;
-}
-
-function wrapGenerator(original) {
-  const wrapped = co.wrap(original);
-  return function() {
-    const args = [].slice.call(arguments);
-    if(args.length === 4){
-      return original.apply(this, args)
+    if (routePromise.catch && typeof routePromise.catch === 'function') {
+      routePromise.catch(err => next(err));
     }
 
-    const res = args[1];
-    const next = args[2];
-
-    return wrapped.apply(this, args).then(() => {
-      !res.headersSent && next();
-    }).catch(err => next(err || {}));
-  };
-}
-
-function wrapAsync(fn) {
-  return function(){
-    const args = [].slice.call(arguments);
-    const val = fn.apply(this, args);
-
-    if(args.length !== 4) {
-      val.catch(err => args[2](err || {}));
-    }
-
-    return val;
+    return routePromise;
   }
-}
+};

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const co = require('co');
-const Layer = require.main.require('express/lib/router/layer');
+const Layer = require('express/lib/router/layer');
 
 Object.defineProperty(Layer.prototype, "handle", {
   enumerable: true,

--- a/index.js
+++ b/index.js
@@ -4,7 +4,10 @@ Object.defineProperty(Layer.prototype, "handle", {
   enumerable: true,
   get: function() { return this.__handle; },
   set: function(fn) {
-    fn = wrap(fn);
+    
+    if(fn.length !== 4){
+      fn = wrap(fn);
+    }
 
     this.__handle = fn;
   }

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ function wrap(fn) {
   return (req, res, next) => {
     const routePromise = fn(req, res, next);
 
-    if (routePromise.catch && typeof routePromise.catch === 'function') {
+    if (routePromise && routePromise.catch && typeof routePromise.catch === 'function') {
       routePromise.catch(err => next(err));
     }
 

--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ function wrapGenerator(original) {
   return function(req, res, next = function() {}) {
     wrapped(req, res).then(() => {
       !res.headersSent && next();
-    }).catch(next);
+    }).catch(err => next(err || {}));
   };
 };
 
@@ -40,7 +40,8 @@ function wrapAsync(fn) {
   return (req, res, next) => {
     const routePromise = fn(req, res, next);
     if (routePromise.catch) {
-      routePromise.catch(err => next(err));
+      routePromise.catch(err => next(err || {}));
     }
+    return routePromise;
   }
 };

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const co = require('co');
-const Layer = require('express/lib/router/layer');
+const Layer = require.main.require('express/lib/router/layer');
 
 Object.defineProperty(Layer.prototype, "handle", {
   enumerable: true,
@@ -25,23 +25,34 @@ function isGenerator(fn) {
 function isAsync(fn) {
   const type = Object.toString.call(fn.constructor);
   return type.indexOf('AsyncFunction') !== -1;
-};
+}
 
 function wrapGenerator(original) {
   const wrapped = co.wrap(original);
-  return function(req, res, next = function() {}) {
-    wrapped(req, res).then(() => {
+  return function() {
+    const args = [].slice.call(arguments);
+    if(args.length === 4){
+      return original.apply(this, args)
+    }
+
+    const res = args[1];
+    const next = args[2];
+
+    return wrapped.apply(this, args).then(() => {
       !res.headersSent && next();
     }).catch(err => next(err || {}));
   };
-};
+}
 
 function wrapAsync(fn) {
-  return (req, res, next) => {
-    const routePromise = fn(req, res, next);
-    if (routePromise.catch) {
-      routePromise.catch(err => next(err || {}));
+  return function(){
+    const args = [].slice.call(arguments);
+    const val = fn.apply(this, args);
+
+    if(args.length !== 4) {
+      val.catch(err => args[2](err || {}));
     }
-    return routePromise;
+
+    return val;
   }
-};
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-yields-2",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "ES6 generators and async functions support for expressjs",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
-  "name": "express-yields",
-  "version": "1.0.2",
-  "description": "ES6 Generators support for expressjs",
+  "name": "express-yields-2",
+  "version": "1.0.3",
+  "description": "ES6 generators and async functions support for expressjs",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/MadRabbit/express-yields.git"
+    "url": "git+https://github.com/scottmas/express-yields.git"
   },
   "keywords": [
     "expressjs",
@@ -18,9 +18,9 @@
   "author": "Nikolay Nemshilov",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/MadRabbit/express-yields/issues"
+    "url": "https://github.com/scottmas/express-yields/issues"
   },
-  "homepage": "https://github.com/MadRabbit/express-yields#readme",
+  "homepage": "https://github.com/scottmas/express-yields#readme",
   "dependencies": {
     "co": "^4.6.0"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-yields-2",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "ES6 generators and async functions support for expressjs",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-yields-2",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "ES6 generators and async functions support for expressjs",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-yields-2",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "ES6 generators and async functions support for expressjs",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-yields-2",
-  "version": "1.0.5",
+  "version": "1.1.0",
   "description": "ES6 generators and async functions support for expressjs",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,5 @@
   },
   "homepage": "https://github.com/scottmas/express-yields#readme",
   "dependencies": {
-    "co": "^4.6.0"
   }
 }


### PR DESCRIPTION
The express error handler should still be able to catch rejections with no arguments. This PR allows requests to the following express server to actually get a response instead of hanging forever. 

```javascript
app.get('/foo', async function(req, res){
  await Promise.reject();
  res.sendStatus(200);
});

app.use(function(err, req, res, next){
   res.sendStatus(500);
})
```