### PR TITLE
Don't stop calling next() when headers have been written

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ function wrapGenerator(original) {
   const wrapped = co.wrap(original);
   return function(req, res, next = noop) {
     wrapped(req, res)
-        .then(() => next())
+        .then(() => !res.finished && next())
         .catch(next);
   };
 };
@@ -41,9 +41,7 @@ function wrapGenerator(original) {
 function wrapAsync(fn) {
   return (req, res, next = noop) => {
     fn(req, res, next)
-      .then(() => {
-        !res.headersSent && next();
-      })
+      .then(() => !res.finished && next())
       .catch(next);
   }
 };

--- a/index.js
+++ b/index.js
@@ -32,9 +32,9 @@ function isAsync(fn) {
 function wrapGenerator(original) {
   const wrapped = co.wrap(original);
   return function(req, res, next = noop) {
-    wrapped(req, res).then(() => {
-      !res.headersSent && next();
-    }).catch(next);
+    wrapped(req, res)
+        .then(() => next())
+        .catch(next);
   };
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-yields",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "ES6 Generators support for expressjs",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
It's undesirable and unnecessary to stop calling next() when res.headersSent becomes true. If headers have been sent prematurely, better bubble up the error to the user than silently halt in the middle of handling.